### PR TITLE
Fix to debug mode error

### DIFF
--- a/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php
+++ b/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php
@@ -14,8 +14,8 @@ if (file_exists(__DIR__.'/../../lib/fb.php')) {
   include_once __DIR__.'/../../../../Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/FBProductFeedSamples.php')) {
-  include_once 'FBProductFeedSamples.php';
+if (file_exists(__DIR__.'/../../Model/FBProductFeedSamples.php')) {
+  include_once __DIR__.'/../../Model/FBProductFeedSamples.php';
 } else {
   include_once 'Facebook_AdsExtension_Model_FBProductFeedSamples.php';
 }


### PR DESCRIPTION
Error in question was:

Warning: include_once(Facebook_AdsExtension_Model_FBProductFeedSamples.php): failed to open stream: No such file or directory  in /public_html/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php on line 20

#0 /public_html/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php(20): mageCoreErrorHandler(2, 'include_once(Fa...', '', 20, Array)
#1 /public_html/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php(20): include_once()
#2 /public_html/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(337): include('')
#3 /public_html/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(308): Mage_Core_Controller_Varien_Router_Standard->_includeControllerClass('', 'Facebook_AdsExt...')
#4 /public_html/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(196): Mage_Core_Controller_Varien_Router_Standard->_validateControllerClassName('Facebook_AdsExt...', 'fbdebug')
#5 /public_html/app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#6 /public_html/app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch()
#7 /public_html/app/Mage.php(683): Mage_Core_Model_App->run(Array)
#8 /public_html/index.php(89): Mage::run('', 'store')